### PR TITLE
Handle many more slowlog messages, parse more statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 fluent-plugin-mongo-slow-query
 ==============================
 # Usage
-It will be helpful to find out the slow operations of MongoDB and ayalyze the query prototype.  
+It will be helpful to find out the slow operations of MongoDB and ayalyze the query prototype.
 The usage is almost same as **in_tail**.
 
 # Install
@@ -16,20 +16,31 @@ The usage is almost same as **in_tail**.
 ```
 
 # Notice
-The configuration parameters of **in_mongo_slow_query** are same to **in_tail**.  
-The **format** is designed for MongoDB log record. 
+The configuration parameters of **in_mongo_slow_query** are same to **in_tail**.
+The **format** is designed for MongoDB log record.
 ```
-format /(?<time>.*) \[\w+\] (?<op>[^ ]+) (?<ns>[^ ]+) ((?<detail>(query: (?<query>\{.+\}) update: \{.*\}))|((?<detail>(query: (?<query>\{.+\}))) planSummary: .*)|((?<detail>query: (?<query>\{.+\})))) .* (?<ms>\d+)ms/
+format /^(?<time>[^ ]+) \[\w+\] (?<op>\w+) (?<ns>[\w-]+\.[\-\w\$]+)(?: (?<command>[\-\w\$]+): (?:(?<commandDetail>\w+) )?(?:(?:(?<query>\{.*\}) planSummary: (?<planSummary>\w+(?: \{.*\})?)?|(?<query>\{.*\}))))?(?: (?:nscanned:(?<nscanned>\d+)|nMatched:(?<nMatched>\d+)|nModified:(?<nModified>\d+)|numYields:(?<numYields>\d+)|reslen:(?<reslen>\d+)|\w+:\d+|locks\(micros\)(?: (?:r:(?<lockread>\d+)|w:(?<lockwrite>\d+)|R:(?<lockglobread>\d+)|W:(?<lockglobwrite>\d+)|\w:\d+))))* (?<ms>\d+)ms$/
 ```
 
 - **time** the local time of host that the MongoDB instance running on
 - **op** the type of operation, for example: query update remove
 - **ns** the namespace that is consist by both database and collection
-- **detail** the content of operation
-- **query**  
-    the prototype of query, for example:  
-    { address: { country: "China", city: "Beijing" } } => { address.country, address.city }  
-    { ts: { $gt: 1411029300, $lt: 1411029302 } => { ts.$gt, ts.$lt }  
+- **query**
+    the prototype of query, for example:
+    { address: { country: "China", city: "Beijing" } } => { address.country, address.city }
+    { ts: { $gt: 1411029300, $lt: 1411029302 } => { ts.$gt, ts.$lt }
     With the prototype, it's convenient to stat the slow query.
 - **ms** the time cost of operation, unit: ms
+- **command** command/insert/findAndModify
+- **commandDetail** details of the command executed
+- **planSummary** summary of the query execution plan
+- **nscanned** number of documents scanned
+- **nMatched** number of matching documents
+- **nModified** number of modified documents
+- **numYields** number of yields
+- **reslen** response length
+- **lockread** (float) read lock time in milliseconds, to microsecond precision
+- **lockwrite** (float) write lock time in milliseconds, to microsecond precision
+- **lockglobread** (float) global read lock time in milliseconds, to microsecond precision
+- **lockglobwrite** (float) global write lock time in milliseconds, to microsecond precision
 

--- a/lib/fluent/plugin/in_mongo_slow_query.rb
+++ b/lib/fluent/plugin/in_mongo_slow_query.rb
@@ -41,7 +41,7 @@ module Fluent
                     line.chomp!  # remove \n
                     time, record = parse_line(line)
                     if time && record
-                        record["query"] = get_query_prototype(record["query"])
+                        record["query"] = get_query_prototype(record["query"]) if record["query"]
                         record["ms"] = record["ms"].to_i
                         record["ts"] = time
 


### PR DESCRIPTION
Hi,

I've been evaluating this plugin but noticed that _many_ of the slowlog messages emitted by MongoDB (2.6, at least) don't get parsed and are ignored. 

Here are two examples:

```
2015-01-28T23:18:26.317+0000 [conn12576] command gitter.$cmd command: insert { insert: "XXXX", writeConcern: { w: 1 }, ordered: true, documents: [ { token: "XXXX", userId: null, clientId: ObjectId('XXXXX'), expires: new Date(1423091906177), _id: ObjectId('XXXX'), __v: 0 } ] } keyUpdates:0 numYields:0 locks(micros) w:74 reslen:80 84ms
2015-01-28T17:34:40.030+0000 [conn3] command gitter.$cmd command: dbStats { dbstats: 1 } keyUpdates:0 numYields:0 locks(micros) r:1013657 reslen:298 1013ms
```

I've updated the regular expression to include many more slowlog errors. I've also made the plugin parse some of the statistics, including:
- **nscanned** number of documents scanned
- **nMatched** number of matching documents
- **nModified** number of modified documents
- **numYields** number of yields
- **reslen** response length
- **lockread** (float) read lock time in milliseconds, to microsecond precision
- **lockwrite** (float) write lock time in milliseconds, to microsecond precision
- **lockglobread** (float) global read lock time in milliseconds, to microsecond precision
- **lockglobwrite** (float) global write lock time in milliseconds, to microsecond precision
